### PR TITLE
Issue 8: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,18 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+
+---
+
+<!--
+Thanks for contributing to TubeMQ!
+Please explain your issue precisely, and if possible provide a reproducer
+snippet (this helps resolve issues much quicker).
+-->
+
+**Problem description**
+
+**(optional) Reproducer snippet**
+
+**(optional) Suggestions for an imporvement**
+

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: "\U0001F389 Feature request"
+about: Suggest an idea for this project
+
+---
+
+<!--
+Thanks for contributing TubeMQ!
+Please explain your use case precisely, and if possible provide an example
+snippet.
+-->
+
+**Motivation**
+
+**(optional) Design**
+
+**(optional) Example snippet**
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,12 @@
+---
+name: "❓ Question"
+about: Please use https://discuss.akka.io for questions
+
+---
+
+<!--
+Welcome to TubeMQ community!
+Please try to describe your question in English and start the title with
+[question].
+-->
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 /.metadata/
 *.class
 .*
+!.github/
 !.gitignore
 !.gitkeep
 tube-server/test/


### PR DESCRIPTION
Visual results with this patch

<img width="1680" alt="issue-template-0" src="https://user-images.githubusercontent.com/18818196/65063742-7365c900-d9b1-11e9-9d29-4c076595cede.png">
<img width="1680" alt="issue-template-1" src="https://user-images.githubusercontent.com/18818196/65063743-7365c900-d9b1-11e9-91d4-e8a34d741d54.png">
<img width="1680" alt="issue-template-2" src="https://user-images.githubusercontent.com/18818196/65063744-73fe5f80-d9b1-11e9-90d5-d84137113ed4.png">
<img width="1680" alt="issue-template-3" src="https://user-images.githubusercontent.com/18818196/65063746-7496f600-d9b1-11e9-9111-e8e25050ddda.png">

You can also try it out by creating issues in https://github.com/TisonKun/TubeMQ ([issues](https://github.com/TisonKun/TubeMQ/issues) -> [New Issue](https://github.com/TisonKun/TubeMQ/issues/new/choose))