### PR TITLE
fixed checking broker or master process

### DIFF
--- a/bin/broker.sh
+++ b/bin/broker.sh
@@ -49,7 +49,7 @@ PID_FILE="$PID_DIR/.run.pid"
 function running(){
 	if [ -f "$PID_FILE" ]; then
 		pid=$(cat "$PID_FILE")
-		process=`ps aux | grep " $pid "|grep "\-Dtube\.home=$BASE_DIR" | grep -v grep`;
+		process=`ps aux | grep " $pid "|grep "\-Dtubemq\.home=$BASE_DIR" | grep -v grep`;
 		if [ "$process" == "" ]; then
 	    		return 1;
 		else

--- a/bin/broker.sh
+++ b/bin/broker.sh
@@ -49,9 +49,9 @@ PID_FILE="$PID_DIR/.run.pid"
 function running(){
 	if [ -f "$PID_FILE" ]; then
 		pid=$(cat "$PID_FILE")
-		process=`ps aux | grep " $pid " | grep -v grep`;
+		process=`ps aux | grep " $pid "|grep "\-Dtube\.home=$BASE_DIR" | grep -v grep`;
 		if [ "$process" == "" ]; then
-	    	return 1;
+	    		return 1;
 		else
 			return 0;
 		fi

--- a/bin/master.sh
+++ b/bin/master.sh
@@ -49,7 +49,7 @@ PID_FILE="$PID_DIR/.master.run.pid"
 function running(){
 	if [ -f "$PID_FILE" ]; then
 		pid=$(cat "$PID_FILE")
-		process=`ps aux | grep " $pid "|grep "\-Dtube\.home=$BASE_DIR" | grep -v grep`;
+		process=`ps aux | grep " $pid "|grep "\-Dtubemq\.home=$BASE_DIR" | grep -v grep`;
 		if [ "$process" == "" ]; then
 	    	return 1;
 		else

--- a/bin/master.sh
+++ b/bin/master.sh
@@ -49,7 +49,7 @@ PID_FILE="$PID_DIR/.master.run.pid"
 function running(){
 	if [ -f "$PID_FILE" ]; then
 		pid=$(cat "$PID_FILE")
-		process=`ps aux | grep " $pid " | grep -v grep`;
+		process=`ps aux | grep " $pid "|grep "\-Dtube\.home=$BASE_DIR" | grep -v grep`;
 		if [ "$process" == "" ]; then
 	    	return 1;
 		else


### PR DESCRIPTION
The .run.pid file was not deleted when the process exited abnormally. When restarting, if there is a process with the same pid, it will be misjudged that the process already exists.