### PR TITLE
Add travis build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ target/
 !.github/
 !.gitignore
 !.gitkeep
+!.travis.yml
 tube-server/test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Tencent is pleased to support the open source community by making TubeMQ available.
 #
@@ -22,7 +20,10 @@ dist: trusty
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+
+before_cache:
+  - rm -rf $HOME/.m2/repository/com/tencent/tubemq/
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Tencent is pleased to support the open source community by making TubeMQ available.
+#
+# Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+sudo: required
+dist: trusty
+language: java
+
+jdk:
+  - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2
+
+install:
+  - wget https://github.com/protocolbuffers/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
+  - tar -xzvf protobuf-2.5.0.tar.gz
+  - pushd protobuf-2.5.0 && ./configure --prefix=/usr && make && sudo make install && popd
+
+script:
+  - mvn -B -V -e verify


### PR DESCRIPTION
This patch adds basic Travis build configuration file. Once this is merged, we can use Travis for our CI process.

Manually test it on Travis.

@TisonKun @gosonzhang Please help review, thanks