### PR TITLE
add log4j log configuration

### DIFF
--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/consumer/RmtDataCache.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/consumer/RmtDataCache.java
@@ -243,9 +243,6 @@ public class RmtDataCache implements Closeable {
                 return null;
             }
             String key = indexPartition.take();
-            if (key == null) {
-                return null;
-            }
             PartitionExt partitionExt = partitionMap.get(key);
             if (partitionExt == null) {
                 return null;

--- a/tubemq-example/src/main/resources/log4j.properties
+++ b/tubemq-example/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger = info,stdout
-
-log4j.appender.stdout = org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target = System.out
-log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-example/src/main/resources/log4j.properties
+++ b/tubemq-example/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+### 设置###
+log4j.rootLogger = info,stdout
+
+### 输出信息到控制抬 ###
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-example/src/main/resources/log4j.properties
+++ b/tubemq-example/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Tencent is pleased to support the open source community by making TubeMQ available.
+#
+# Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+log4j.rootLogger = info,stdout
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-example/src/main/resources/log4j.properties
+++ b/tubemq-example/src/main/resources/log4j.properties
@@ -1,7 +1,5 @@
-### 设置###
 log4j.rootLogger = info,stdout
 
-### 输出信息到控制抬 ###
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target = System.out
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/tubemq-example/src/main/resources/log4j.properties
+++ b/tubemq-example/src/main/resources/log4j.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-log4j.rootLogger = info,stdout
+log4j.rootLogger = OFF,stdout
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target = System.out
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/tubemq-server/src/main/resources/log4j.properties
+++ b/tubemq-server/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+### 设置###
+log4j.rootLogger = debug,stdout
+
+### 输出信息到控制抬 ###
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-server/src/main/resources/log4j.properties
+++ b/tubemq-server/src/main/resources/log4j.properties
@@ -1,7 +1,5 @@
-### 设置###
 log4j.rootLogger = debug,stdout
 
-### 输出信息到控制抬 ###
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target = System.out
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout

--- a/tubemq-server/src/main/resources/log4j.properties
+++ b/tubemq-server/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Tencent is pleased to support the open source community by making TubeMQ available.
+#
+# Copyright (C) 2012-2019 Tencent. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+log4j.rootLogger = info,stdout
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-server/src/main/resources/log4j.properties
+++ b/tubemq-server/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger = debug,stdout
-
-log4j.appender.stdout = org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target = System.out
-log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/tubemq-server/src/main/resources/log4j.properties
+++ b/tubemq-server/src/main/resources/log4j.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-log4j.rootLogger = info,stdout
+log4j.rootLogger = OFF,stdout
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target = System.out
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout


### PR DESCRIPTION
Add log4j log configuration for printing logs to the console during local development debugging

***
添加log4j日志配置以在本地开发调试期间将日志打印到控制台