### PR TITLE
AbstractFileConfig getXxx() method optimization

### DIFF
--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/common/fileconfig/AbstractFileConfig.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/common/fileconfig/AbstractFileConfig.java
@@ -101,8 +101,7 @@ public abstract class AbstractFileConfig {
             return defaultValue;
         } else {
             try {
-                final Long rt = Long.valueOf(value);
-                return rt.intValue();
+                return Integer.parseInt(value);
             } catch (NumberFormatException e) {
                 logger.warn("Long.valueOf(" + value + ") failure for key=" + key);
                 return defaultValue;
@@ -124,8 +123,7 @@ public abstract class AbstractFileConfig {
                     .append("Blank value for ").append(key).toString());
         } else {
             try {
-                final Long rt = Long.valueOf(value);
-                return rt.intValue();
+                return Integer.parseInt(value);
             } catch (NumberFormatException e) {
                 throw new NullPointerException(new StringBuilder(256)
                         .append("Translate key(").append(key).append(")'s value ")
@@ -147,13 +145,7 @@ public abstract class AbstractFileConfig {
             throw new NullPointerException(new StringBuilder(256)
                     .append("Blank value for ").append(key).toString());
         } else {
-            try {
-                return Boolean.valueOf(value);
-            } catch (NumberFormatException e) {
-                throw new NullPointerException(new StringBuilder(256)
-                        .append("Translate key(").append(key).append(")'s value ")
-                        .append(value).append(" to boolean failure!").toString());
-            }
+            return Boolean.parseBoolean(value);
         }
     }
 
@@ -171,7 +163,7 @@ public abstract class AbstractFileConfig {
                     .append("Blank value for ").append(key).toString());
         } else {
             try {
-                return Long.valueOf(value);
+                return Long.parseLong(value);
             } catch (NumberFormatException e) {
                 throw new NullPointerException(new StringBuilder(256)
                         .append("Translate key(").append(key).append(")'s value ")


### PR DESCRIPTION
1. use Integer/Long/Boolean `parseXxx()` method instead of `valueOf()` method to remove unnecessary unboxing
2. remove throw NumberFormatException from `getBoolean()` method