### PR TITLE
Refactor MAMessageProducerExample

### DIFF
--- a/tubemq-example/src/main/java/com/tencent/tubemq/example/MAMessageProducerExample.java
+++ b/tubemq-example/src/main/java/com/tencent/tubemq/example/MAMessageProducerExample.java
@@ -17,9 +17,6 @@
 
 package com.tencent.tubemq.example;
 
-import com.tencent.tubemq.corebase.Message;
-import com.tencent.tubemq.corebase.TErrCodeConstants;
-import com.tencent.tubemq.corebase.utils.ThreadUtils;
 import com.tencent.tubemq.client.config.TubeClientConfig;
 import com.tencent.tubemq.client.exception.TubeClientException;
 import com.tencent.tubemq.client.factory.MessageSessionFactory;
@@ -27,53 +24,66 @@ import com.tencent.tubemq.client.factory.TubeMultiSessionFactory;
 import com.tencent.tubemq.client.producer.MessageProducer;
 import com.tencent.tubemq.client.producer.MessageSentCallback;
 import com.tencent.tubemq.client.producer.MessageSentResult;
+import com.tencent.tubemq.corebase.Message;
+import com.tencent.tubemq.corebase.TErrCodeConstants;
+import com.tencent.tubemq.corebase.utils.ThreadUtils;
 import org.apache.commons.codec.binary.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-
+/**
+ *
+ */
 public class MAMessageProducerExample {
-    private static final Logger logger =
-            LoggerFactory.getLogger(MAMessageProducerExample.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MAMessageProducerExample.class);
+    private static final AtomicLong SENT_SUCC_COUNTER = new AtomicLong(0);
+    private static final List<MessageProducer> PRODUCER_LIST = new ArrayList<>();
     private static final int MAX_PRODUCER_NUM = 100;
-    private static final AtomicLong sentSuccCounter = new AtomicLong(0);
-    private static final List<MessageProducer> producerList = new ArrayList<MessageProducer>();
-    private static int numSessionFactory = 10;
-    private static TreeSet<String> topicSet;
+    private static final int SESSION_FACTORY_NUM = 10;
+
+    private static Set<String> topicSet;
     private static int msgCnt;
     private static int producerCnt;
     private static byte[] sendData;
-    private final HashMap<MessageProducer, SendRunner> producerMap = new HashMap<MessageProducer, SendRunner>();
+
+    private final String[] arrayKey = {"aaa", "bbb", "ac", "dd", "eee", "fff", "gggg", "hhhh"};
+    private final Set<String> filters = new TreeSet<>();
+    private final Map<MessageProducer, Sender> producerMap = new HashMap<>();
+    private final List<MessageSessionFactory> sessionFactoryList = new ArrayList<>();
     private final ExecutorService sendExecutorService =
             Executors.newFixedThreadPool(MAX_PRODUCER_NUM, new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable r) {
-                    return new Thread(r, "senderRunner_" + producerMap.size());
+                    return new Thread(r, "sender_" + producerMap.size());
                 }
             });
-    private final String[] arrayKey = {"aaa", "bbb", "ac", "dd", "eee", "fff", "gggg", "hhhh"};
-    private AtomicInteger rr = new AtomicInteger(0);
-    private TreeSet<String> filters = new TreeSet<String>();
+    private final AtomicInteger producerIndex = new AtomicInteger(0);
+
     private int keyCount = 0;
     private int sentCount = 0;
-    private ArrayList<MessageSessionFactory> sessionFactoryList = new ArrayList<MessageSessionFactory>();
 
-    public MAMessageProducerExample(final String localHost, final String masterHostAndPort) throws Exception {
-        filters.add("aaa");
-        filters.add("bbb");
+    public MAMessageProducerExample(String localHost, String masterHostAndPort) throws Exception {
+        this.filters.add("aaa");
+        this.filters.add("bbb");
+
         TubeClientConfig clientConfig = new TubeClientConfig(localHost, masterHostAndPort);
-        //clientConfig.setNettyWriteBufferHighWaterMark(1024 * 1024 * 500);
-        //clientConfig.setLinkMaxAllowedDelayedMsgCount(80000);
-        for (int i = 0; i < numSessionFactory; i++) {
+        for (int i = 0; i < SESSION_FACTORY_NUM; i++) {
             this.sessionFactoryList.add(new TubeMultiSessionFactory(clientConfig));
         }
     }
@@ -81,71 +91,60 @@ public class MAMessageProducerExample {
     public static void main(String[] args) {
         final String localHost = args[0];
         final String masterHostAndPort = args[1];
-        String topics = args[2];
-        List<String> topicList = Arrays.asList(topics.split(","));
-        topicSet = new TreeSet<String>(topicList);
+
+        final String topics = args[2];
+        final List<String> topicList = Arrays.asList(topics.split(","));
+
+        topicSet = new TreeSet<>(topicList);
+
         msgCnt = Integer.parseInt(args[3]);
-        producerCnt = 10;
-        if (args.length > 4) {
-            producerCnt = Integer.parseInt(args[4]);
-        }
-        if (producerCnt > MAX_PRODUCER_NUM) {
-            producerCnt = MAX_PRODUCER_NUM;
-        }
+        producerCnt = Math.min(args.length > 4 ? Integer.parseInt(args[4]) : 10, MAX_PRODUCER_NUM);
 
-        logger.info("MAMessageProducerExample.main started...");
+        LOG.info("MAMessageProducerExample.main started...");
 
-        String body = "This is a test message from multi-session factory.";
-        byte[] bodyData = StringUtils.getBytesUtf8(body);
-        int bodyDataLen = bodyData.length;
-        int offset = 0;
+        final byte[] transmitData = StringUtils.getBytesUtf8("This is a test message from multi-session factory.");
         final ByteBuffer dataBuffer1 = ByteBuffer.allocate(1024);
+
         while (dataBuffer1.hasRemaining()) {
-            offset = dataBuffer1.arrayOffset();
-            if (dataBuffer1.remaining() > bodyDataLen) {
-                dataBuffer1.put(bodyData, offset, bodyDataLen);
-            } else {
-                dataBuffer1.put(bodyData,
-                        offset, dataBuffer1.remaining());
-            }
+            int offset = dataBuffer1.arrayOffset();
+            dataBuffer1.put(transmitData, offset, Math.min(dataBuffer1.remaining(), transmitData.length));
         }
 
         dataBuffer1.flip();
         sendData = dataBuffer1.array();
 
         try {
-            MAMessageProducerExample messageProducer =
-                    new MAMessageProducerExample(localHost, masterHostAndPort);
+            MAMessageProducerExample messageProducer = new MAMessageProducerExample(localHost, masterHostAndPort);
 
             messageProducer.startService();
 
-            while (sentSuccCounter.get() < msgCnt * producerCnt * topicSet.size()) {
+            while (SENT_SUCC_COUNTER.get() < msgCnt * producerCnt * topicSet.size()) {
                 Thread.sleep(1000);
             }
-            messageProducer.getProducerMap().clear();
+            messageProducer.producerMap.clear();
             messageProducer.shutdown();
 
         } catch (TubeClientException e) {
-            logger.error("TubeClientException: ", e);
+            LOG.error("TubeClientException: ", e);
         } catch (Throwable e) {
-            logger.error("Throwable: ", e);
+            LOG.error("Throwable: ", e);
         }
 
     }
 
     public MessageProducer createProducer() throws TubeClientException {
-        int index = (rr.incrementAndGet()) % numSessionFactory;
+        int index = (producerIndex.incrementAndGet()) % SESSION_FACTORY_NUM;
         return sessionFactoryList.get(index).createProducer();
     }
 
     private void startService() throws TubeClientException {
         for (int i = 0; i < producerCnt; i++) {
-            producerList.add(createProducer());
+            PRODUCER_LIST.add(createProducer());
         }
 
-        for (MessageProducer producer : producerList) {
+        for (MessageProducer producer : PRODUCER_LIST) {
             if (producer != null) {
-                producerMap.put(producer, new SendRunner(producer));
+                producerMap.put(producer, new Sender(producer));
                 sendExecutorService.submit(producerMap.get(producer));
             }
         }
@@ -154,20 +153,16 @@ public class MAMessageProducerExample {
 
     public void shutdown() throws Throwable {
         sendExecutorService.shutdownNow();
-        for (int i = 0; i < numSessionFactory; i++) {
+        for (int i = 0; i < SESSION_FACTORY_NUM; i++) {
             sessionFactoryList.get(i).shutdown();
         }
 
     }
 
-    public HashMap<MessageProducer, SendRunner> getProducerMap() {
-        return producerMap;
-    }
-
-    public class SendRunner implements Runnable {
+    public class Sender implements Runnable {
         private MessageProducer producer;
 
-        public SendRunner(MessageProducer producer) {
+        public Sender(MessageProducer producer) {
             this.producer = producer;
         }
 
@@ -175,8 +170,8 @@ public class MAMessageProducerExample {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmm");
             try {
                 producer.publish(topicSet);
-            } catch (Throwable e2) {
-                logger.error("publish exception: ", e2);
+            } catch (Throwable t) {
+                LOG.error("publish exception: ", t);
             }
             for (int i = 0; i < msgCnt; i++) {
                 long millis = System.currentTimeMillis();
@@ -185,57 +180,59 @@ public class MAMessageProducerExample {
                         Message message = new Message(topic, sendData);
                         message.setAttrKeyVal("index", String.valueOf(1));
                         message.setAttrKeyVal("dataTime", String.valueOf(millis));
+
                         String keyCode = arrayKey[sentCount++ % arrayKey.length];
-                        message.putSystemHeader(keyCode, sdf.format(new Date(millis))); // 定义到分,不能到秒
+
+                        // date format is accurate to minute, not to second
+                        message.putSystemHeader(keyCode, sdf.format(new Date(millis)));
                         if (filters.contains(keyCode)) {
                             keyCount++;
                         }
-                        // 同步发送方式
+
+                        // next line sends message synchronously, which is not recommended
                         //producer.sendMessage(message);
 
-                        // 异步发送方式，推荐使用
+                        // send message asynchronously, recommended
                         producer.sendMessage(message, new DefaultSendCallback());
                     } catch (Throwable e1) {
-                        logger.error("sendMessage exception: ", e1);
+                        LOG.error("sendMessage exception: ", e1);
                     }
-                    if (true) {
-                        if (i % 5000 == 0) {
-                            ThreadUtils.sleep(3000);
-                        } else if (i % 4000 == 0) {
-                            ThreadUtils.sleep(2000);
-                        } else if (i % 2000 == 0) {
-                            ThreadUtils.sleep(800);
-                        } else if (i % 1000 == 0) {
-                            ThreadUtils.sleep(400);
-                        }
+
+                    if (i % 5000 == 0) {
+                        ThreadUtils.sleep(3000);
+                    } else if (i % 4000 == 0) {
+                        ThreadUtils.sleep(2000);
+                    } else if (i % 2000 == 0) {
+                        ThreadUtils.sleep(800);
+                    } else if (i % 1000 == 0) {
+                        ThreadUtils.sleep(400);
                     }
                 }
             }
             try {
                 producer.shutdown();
             } catch (Throwable e) {
-                logger.error("producer shutdown error: ", e);
+                LOG.error("producer shutdown error: ", e);
             }
 
         }
     }
 
-    final class DefaultSendCallback implements MessageSentCallback {
-
+    private class DefaultSendCallback implements MessageSentCallback {
         public void onMessageSent(MessageSentResult result) {
             if (result.isSuccess()) {
-                if (sentSuccCounter.incrementAndGet() % 1000 == 0) {
-                    logger.info("Send " + sentSuccCounter.get() + " message, keyCount is " + keyCount);
+                if (SENT_SUCC_COUNTER.incrementAndGet() % 1000 == 0) {
+                    LOG.info("Send {} message, keyCount is {}", SENT_SUCC_COUNTER.get(), keyCount);
                 }
             } else {
                 if (result.getErrCode() != TErrCodeConstants.SERVER_RECEIVE_OVERFLOW) {
-                    logger.error("Send message failed!" + result.getErrMsg());
+                    LOG.error("Send message failed!" + result.getErrMsg());
                 }
             }
         }
 
         public void onException(Throwable e) {
-            logger.error("Send message error!", e);
+            LOG.error("Send message error!", e);
         }
     }
 }

--- a/tubemq-example/src/main/java/com/tencent/tubemq/example/MAMessageProducerExample.java
+++ b/tubemq-example/src/main/java/com/tencent/tubemq/example/MAMessageProducerExample.java
@@ -48,7 +48,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- *
+ * This demo shows how to use the multi-connected {@link TubeMultiSessionFactory} in the sample single process.
+ * With {@link TubeMultiSessionFactory}, a single process can establish concurrent physical request connections
+ * to improve throughput from client to broker.
  */
 public class MAMessageProducerExample {
     private static final Logger LOG = LoggerFactory.getLogger(MAMessageProducerExample.class);


### PR DESCRIPTION
1. eliminates Chinese comments
2. generalises types such as TreeMap -> Map
3. mark effective final fields as `final`
4. rename variable a bit and other nit refators

Still mark as draft pull request because we need a javadoc to this example explain what this example really is. And javadoc of `main` at least to explain the usage.

Could you help with the document side @gosonzhang?