### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1122,7 +1122,7 @@ Copyright 2002-2019 The Apache Software Foundation
 Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
 Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
 
-6. fastjson 1.2.58
+6. fastjson 1.2.60
 Copyright 1999-2019 Alibaba Group Holding Ltd.
 
 7. jackson-mapper-asl 1.9.13


### PR DESCRIPTION
The version of fastjson has been upgraded to 1.2.60 in #11 , so we should update the LICENSE file to be consistent.