### PR TITLE
Make protobuf version configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <exec.maven.version>1.6.0</exec.maven.version>
         <build.helper.maven.version>3.0.0</build.helper.maven.version>
         <checkstyle.version>8.17</checkstyle.version>
+        <protobuf.version>2.5.0</protobuf.version>
     </properties>
 
     <repositories>
@@ -223,7 +224,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>2.5.0</version>
+                <version>${protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>


### PR DESCRIPTION
Make protobuf version configurable so that with different user environment one can easily use 

```
mvn clean install -DskipTests -Dprotobuf.version=3.10.0
```

instead of modify `pom.xml` which also pollute git modification tracker.