### PR TITLE
Make je version configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <build.helper.maven.version>3.0.0</build.helper.maven.version>
         <checkstyle.version>8.17</checkstyle.version>
         <protobuf.version>2.5.0</protobuf.version>
+        <je.version>7.3.7</je.version>
     </properties>
 
     <repositories>
@@ -239,7 +240,7 @@
             <dependency>
                 <groupId>com.sleepycat</groupId>
                 <artifactId>je</artifactId>
-                <version>7.3.7</version>
+                <version>${je.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba</groupId>


### PR DESCRIPTION
Considering that the business environment using TubeMQ is java 7 and does not allow upgrades, it's a better support method to adjust the je version to a lower version than 7.3.7, such as 6.1.5.

- - - - - - - 

考虑到使用TubeMQ的商业环境是Java 7，并且不允许升级，将je版本调整为低于7.3.7（例如6.1.5）的版本是一种比较好的支持方法。