### PR TITLE
Adjust the broker heartbeat detection cycle

### DIFF
--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/broker/TubeBroker.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/broker/TubeBroker.java
@@ -209,7 +209,7 @@ public class TubeBroker implements Stoppable, Runnable {
                         if (!shutdown.get()) {
                             long currErrCnt = heartbeatErrors.get();
                             if (currErrCnt > maxReleaseTryCnt) {
-                                if ((currErrCnt - maxReleaseTryCnt) % maxReleaseTryCnt != 0) {
+                                if (currErrCnt % 2 == 0) {
                                     heartbeatErrors.incrementAndGet();
                                     return;
                                 }


### PR DESCRIPTION
Adjust the beat heartbeat attempt to adjust from interval 9 times to 1 time, shorten the detection period duration

see https://github.com/Tencent/TubeMQ/issues/93