### PR TITLE
[hotfix] remove unnecessary assembly directory

### DIFF
--- a/tubemq-client/src/main/assembly/assembly.xml
+++ b/tubemq-client/src/main/assembly/assembly.xml
@@ -32,7 +32,6 @@
             <directory>../</directory>
             <includes>
                 <include>./conf/tools.log4j.properties</include>
-                <include>./logs</include>
             </includes>
             <excludes>
                 <exclude>**/src/**</exclude>

--- a/tubemq-example/src/main/assembly/assembly.xml
+++ b/tubemq-example/src/main/assembly/assembly.xml
@@ -32,7 +32,6 @@
             <directory>../</directory>
             <includes>
                 <include>./conf/tools.log4j.properties</include>
-                <include>./logs</include>
             </includes>
             <excludes>
                 <exclude>**/src/**</exclude>


### PR DESCRIPTION
this PR removes unnecessary assembly `logs` directory in `tubemq-client` and `tube-example` module. `tubemq-client` and `tube-example` does't need logs directory in assembly result.