### PR TITLE
Increase flow control strategy type printing for easier troubleshooting

### DIFF
--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/consumer/BaseMessageConsumer.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/consumer/BaseMessageConsumer.java
@@ -94,9 +94,9 @@ public class BaseMessageConsumer implements MessageConsumer {
     private boolean isCurGroupCtrl = false;
     private AtomicLong lastCheckTime = new AtomicLong(0);
     private final FlowCtrlRuleHandler groupFlowCtrlRuleHandler =
-            new FlowCtrlRuleHandler();
+            new FlowCtrlRuleHandler(false);
     private final FlowCtrlRuleHandler defFlowCtrlRuleHandler =
-            new FlowCtrlRuleHandler();
+            new FlowCtrlRuleHandler(true);
     private final ConsumerSamplePrint samplePrintCtrl =
             new ConsumerSamplePrint();
     private final RpcConfig rpcConfig = new RpcConfig();

--- a/tubemq-client/src/test/java/com/tencent/tubemq/client/consumer/PartitionExtTest.java
+++ b/tubemq-client/src/test/java/com/tencent/tubemq/client/consumer/PartitionExtTest.java
@@ -27,8 +27,8 @@ public class PartitionExtTest {
 
     @Test
     public void testPartitionExt() {
-        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
-        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
+        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler(false);
+        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler(true);
         PartitionExt partition = new PartitionExt(
                 groupFlowCtrlRuleHandler,
                 defFlowCtrlRuleHandler,
@@ -45,8 +45,8 @@ public class PartitionExtTest {
 
     @Test
     public void testPartitionExtSuccess() {
-        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
-        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
+        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler(false);
+        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler(true);
         PartitionExt partition = new PartitionExt(
                 groupFlowCtrlRuleHandler,
                 defFlowCtrlRuleHandler,
@@ -63,8 +63,8 @@ public class PartitionExtTest {
 
     @Test
     public void testPartitionExtError() {
-        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
-        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
+        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler(false);
+        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler(true);
         PartitionExt partition = new PartitionExt(
                 groupFlowCtrlRuleHandler,
                 defFlowCtrlRuleHandler,

--- a/tubemq-client/src/test/java/com/tencent/tubemq/client/consumer/RmtDataCacheTest.java
+++ b/tubemq-client/src/test/java/com/tencent/tubemq/client/consumer/RmtDataCacheTest.java
@@ -34,8 +34,8 @@ public class RmtDataCacheTest {
 
     @Test
     public void testRmtDataCache() {
-        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
-        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler();
+        FlowCtrlRuleHandler groupFlowCtrlRuleHandler = new FlowCtrlRuleHandler(false);
+        FlowCtrlRuleHandler defFlowCtrlRuleHandler = new FlowCtrlRuleHandler(true);
         List<Partition> partitions = new ArrayList<>();
         BrokerInfo brokerInfo = new BrokerInfo(1, "127.0.0.1", 18080);
         Partition expectPartition = new Partition(brokerInfo, "test", 1);

--- a/tubemq-core/src/main/java/com/tencent/tubemq/corebase/policies/FlowCtrlRuleHandler.java
+++ b/tubemq-core/src/main/java/com/tencent/tubemq/corebase/policies/FlowCtrlRuleHandler.java
@@ -43,7 +43,8 @@ import org.slf4j.LoggerFactory;
  * the processing speed
  */
 public class FlowCtrlRuleHandler {
-
+    private final boolean isDefaultHandler;
+    private final String flowCtrlName;
     private static final Logger logger =
             LoggerFactory.getLogger(FlowCtrlRuleHandler.class);
     private final TimeZone timeZone = TimeZone.getTimeZone("GMT+8:00");
@@ -81,7 +82,13 @@ public class FlowCtrlRuleHandler {
     private Map<Integer, List<FlowCtrlItem>> flowCtrlRuleSet =
             new ConcurrentHashMap<Integer, List<FlowCtrlItem>>();
 
-    public FlowCtrlRuleHandler() {
+    public FlowCtrlRuleHandler(boolean isDefault) {
+        this.isDefaultHandler = isDefault;
+        if (this.isDefaultHandler) {
+            flowCtrlName = "Default_FlowCtrl";
+        } else {
+            flowCtrlName = "Group_FlowCtrl";
+        }
 
     }
 
@@ -108,10 +115,10 @@ public class FlowCtrlRuleHandler {
             this.flowCtrlId.set(flowCtrlId);
             this.strFlowCtrlInfo = flowCtrlInfo;
             logger.info(new StringBuilder(512)
-                    .append("[Flow Ctrl] FlowCtrl Rule updated to flowId=")
-                    .append(flowCtrlId).append(",ssdTranslateId=")
-                    .append(ssdTranslateId).append(",qyrPriorityId=")
-                    .append(qyrPriorityId).toString());
+                .append("[Flow Ctrl] Updated ").append(flowCtrlName)
+                .append(" to flowId=").append(flowCtrlId)
+                .append(",ssdTranslateId=").append(ssdTranslateId)
+                .append(",qyrPriorityId=").append(qyrPriorityId).toString());
             this.ssdTranslateId.set(ssdTranslateId);
             this.qryPriorityId.set(qyrPriorityId);
             clearStatisData();

--- a/tubemq-core/src/test/java/com/tencent/tubemq/corebase/policies/TestFlowCtrlRuleHandler.java
+++ b/tubemq-core/src/test/java/com/tencent/tubemq/corebase/policies/TestFlowCtrlRuleHandler.java
@@ -40,7 +40,7 @@ public class TestFlowCtrlRuleHandler {
     @Test
     public void testFlowCtrlRuleHandler() {
         try {
-            FlowCtrlRuleHandler handler = new FlowCtrlRuleHandler();
+            FlowCtrlRuleHandler handler = new FlowCtrlRuleHandler(true);
             handler.updateDefFlowCtrlInfo(1001, 2, 10, mockFlowCtrlInfo());
             TimeZone timeZone = TimeZone.getTimeZone("GMT+8:00");
             Calendar rightNow = Calendar.getInstance(timeZone);

--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/broker/metadata/BrokerMetadataManage.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/broker/metadata/BrokerMetadataManage.java
@@ -42,7 +42,7 @@ public class BrokerMetadataManage implements MetadataManage {
             new PropertyChangeSupport(this);
     // the rule handler of flow control.
     private final FlowCtrlRuleHandler flowCtrlRuleHandler =
-            new FlowCtrlRuleHandler();
+            new FlowCtrlRuleHandler(true);
     // broker's config check sum.
     private int brokerConfCheckSumId = 0;
     // broker's metadata Id.

--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/master/TMaster.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/master/TMaster.java
@@ -1220,19 +1220,20 @@ public class TMaster extends HasThread implements MasterService, Stoppable {
         int reqQureyPriorityId = request.hasQryPriorityId()
                 ? request.getQryPriorityId() : TBaseConstants.META_VALUE_UNDEFINED;
         if (request.getTakeConfInfo()) {
-            strBuffer.append("[Broker Report] heartbeat report: broker configure id : ")
-                    .append(request.getCurBrokerConfId())
-                    .append(", checksum id  is ").append(request.getConfCheckSumId())
-                    .append(", hasFlowCheckId=").append(request.hasFlowCheckId())
-                    .append(",reFlowCtrlId=").append(reFlowCtrlId)
-                    .append(", reqSsdTransId=").append(reqSsdTransId)
-                    .append(", reqQureyPriorityId=").append(reqQureyPriorityId)
-                    .append(", default broker configure is ").append(request.getBrokerDefaultConfInfo())
-                    .append(", broker topic configure is ").append(request.getBrokerTopicSetConfInfoList())
-                    .append(", broker is Online : ").append(request.getBrokerOnline())
-                    .append(", readStatusRpt=").append(request.getReadStatusRpt())
-                    .append(", writeStatusRpt=").append(request.getWriteStatusRpt())
-                    .append(", current brokerSyncStatusInfo is ");
+            strBuffer.append("[Broker Report] heartbeat report: brokerId=")
+                .append(request.getBrokerId()).append(", configureId=")
+                .append(request.getCurBrokerConfId())
+                .append(", checksumId=").append(request.getConfCheckSumId())
+                .append(", hasFlowCheckId=").append(request.hasFlowCheckId())
+                .append(",reFlowCtrlId=").append(reFlowCtrlId)
+                .append(", reqSsdTransId=").append(reqSsdTransId)
+                .append(", reqQureyPriorityId=").append(reqQureyPriorityId)
+                .append(", default broker configure is ").append(request.getBrokerDefaultConfInfo())
+                .append(", broker topic configure is ").append(request.getBrokerTopicSetConfInfoList())
+                .append(", broker is Online : ").append(request.getBrokerOnline())
+                .append(", readStatusRpt=").append(request.getReadStatusRpt())
+                .append(", writeStatusRpt=").append(request.getWriteStatusRpt())
+                .append(", current brokerSyncStatusInfo is ");
             logger.info(brokerSyncStatusInfo.toJsonString(strBuffer, true).toString());
             strBuffer.delete(0, strBuffer.length());
         }

--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/master/web/handler/WebAdminFlowRuleHandler.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/master/web/handler/WebAdminFlowRuleHandler.java
@@ -368,7 +368,7 @@ public class WebAdminFlowRuleHandler {
             List<Integer> ruleTypes = Arrays.asList(0, 1, 2, 3);
             inFlowCtrlInfo = String.valueOf(inFlowCtrlInfo).trim();
             FlowCtrlRuleHandler flowCtrlRuleHandler =
-                    new FlowCtrlRuleHandler();
+                new FlowCtrlRuleHandler(true);
             Map<Integer, List<FlowCtrlItem>> flowCtrlItemMap =
                     flowCtrlRuleHandler.parseFlowCtrlInfo(inFlowCtrlInfo);
             for (Integer typeId : ruleTypes) {


### PR DESCRIPTION
Improvements to log output: When the current flow control policy is updated, the log only prints the ID, there is no type of flow control policy,not friendly.
－－－－－－－－
日志输出的改进：当更新当前流控制策略时，日志仅显示ID，没有流控制策略类型，不友好。