### PR TITLE
Optimization: Reducing repeated nesting of TubeClientException exception

### DIFF
--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/factory/TubeBaseSessionFactory.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/factory/TubeBaseSessionFactory.java
@@ -129,7 +129,15 @@ public class TubeBaseSessionFactory implements InnerSessionFactory {
     @Override
     public MessageProducer createProducer() throws TubeClientException {
         this.brokerRcvQltyStats.startBrokerStatistic();
-        this.producerManager.start();
+        try {
+            this.producerManager.start();
+        } catch (Throwable e) {
+            if (e instanceof TubeClientException) {
+                throw (TubeClientException) e;
+            } else {
+                throw new TubeClientException("Create Producer failure, ", e);
+            }
+        }
         return this.addClient(new SimpleMessageProducer(this, this.tubeClientConfig));
     }
 

--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/producer/ProducerManager.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/producer/ProducerManager.java
@@ -150,9 +150,9 @@ public class ProducerManager {
     /**
      * Start the producer manager.
      *
-     * @throws TubeClientException
+     * @throws Throwable
      */
-    public void start() throws TubeClientException {
+    public void start() throws Throwable {
         if (nodeStatus.get() <= 0) {
             if (nodeStatus.compareAndSet(-1, 0)) {
                 register2Master();
@@ -375,7 +375,7 @@ public class ProducerManager {
         }
     }
 
-    private void register2Master() throws TubeClientException {
+    private void register2Master() throws Throwable {
         int remainingRetry =
                 this.tubeClientConfig.getMaxRegisterRetryTimes();
         StringBuilder sBuilder = new StringBuilder(512);
@@ -419,7 +419,7 @@ public class ProducerManager {
                     //
                 }
                 if (remainingRetry <= 0) {
-                    throw new TubeClientException("Register producer exception, error is ", e);
+                    throw e;
                 }
             }
         } while (true);


### PR DESCRIPTION
When register2Master() throws a TubeClientException, the exception will be repeatedly nested with TubeClientException again, which is not convenient for problem analysis and processing after the exception is thrown.
- - - - - - - - - - - -
当register2Master() 引发TubeClientException时，该异常将再次与TubeClientException重复嵌套，这在引发异常后不方便进行问题分析和处理。