### PR TITLE
Optimize SERVICE_UNAVILABLE error handling logic

### DIFF
--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/config/TubeClientConfig.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/config/TubeClientConfig.java
@@ -69,6 +69,7 @@ public class TubeClientConfig {
     private long linkStatsForbiddenDurationMs = RpcConstants.CFG_LQ_FORBIDDEN_DURATION_MS;
     private int linkStatsMaxAllowedFailTimes = RpcConstants.CFG_LQ_MAX_ALLOWED_FAIL_COUNT;
     private double linkStatsMaxForbiddenRate = RpcConstants.CFG_LQ_MAX_FAIL_FORBIDDEN_RATE;
+    private long unAvailableFbdDurationMs = RpcConstants.CFG_UNAVAILABLE_FORBIDDEN_DURATION_MS;
     private double maxSentForbiddenRate = 0.15;
     private long maxForbiddenCheckDuration = 30000;
 
@@ -163,6 +164,14 @@ public class TubeClientConfig {
         } else {
             this.rpcConnProcesserCnt = rpcConnProcesserCnt;
         }
+    }
+
+    public long getUnAvailableFbdDurationMs() {
+        return unAvailableFbdDurationMs;
+    }
+
+    public void setUnAvailableFbdDurationMs(long unAvailableFbdDurationMs) {
+        this.unAvailableFbdDurationMs = unAvailableFbdDurationMs;
     }
 
     public int getRpcNettyWorkMemorySize() {
@@ -488,6 +497,9 @@ public class TubeClientConfig {
         if (linkStatsForbiddenDurationMs != that.linkStatsForbiddenDurationMs) {
             return false;
         }
+        if (unAvailableFbdDurationMs != that.unAvailableFbdDurationMs) {
+            return false;
+        }
         if (linkStatsMaxAllowedFailTimes != that.linkStatsMaxAllowedFailTimes) {
             return false;
         }
@@ -541,31 +553,32 @@ public class TubeClientConfig {
             sBuilder.append("\"").append(item).append("\"");
         }
         return sBuilder.append("],\"rpcReadTimeoutMs\":").append(this.rpcReadTimeoutMs)
-                .append(",\"rpcConnProcesserCnt\":").append(this.rpcConnProcesserCnt)
-                .append(",\"rpcNnettyWorkMemorySize\":").append(this.rpcNnettyWorkMemorySize)
-                .append(",\"rpcRspCallBackThreadCnt\":").append(this.rpcRspCallBackThreadCnt)
-                .append(",\"nettyWriteBufferHighWaterMark\":").append(this.nettyWriteBufferHighWaterMark)
-                .append(",\"nettyWriteBufferLowWaterMark\":").append(this.nettyWriteBufferLowWaterMark)
-                .append(",\"maxRegisterRetryTimes\":").append(this.maxRegisterRetryTimes)
-                .append(",\"regFailWaitPeriodMs\":").append(this.regFailWaitPeriodMs)
-                .append(",\"maxHeartBeatRetryTimes\":").append(this.maxHeartBeatRetryTimes)
-                .append(",\"heartbeatPeriodMs\":").append(this.heartbeatPeriodMs)
-                .append(",\"heartbeatPeriodAfterFail\":").append(this.heartbeatPeriodAfterFail)
-                .append(",\"linkStatsDurationMs\":").append(this.linkStatsDurationMs)
-                .append(",\"linkStatsForbiddenDurationMs\":").append(this.linkStatsForbiddenDurationMs)
-                .append(",\"linkStatsMaxAllowedFailTimes\":").append(this.linkStatsMaxAllowedFailTimes)
-                .append(",\"linkStatsMaxForbiddenRate\":").append(this.linkStatsMaxForbiddenRate)
-                .append(",\"maxSentForbiddenRate\":").append(this.maxSentForbiddenRate)
-                .append(",\"maxForbiddenCheckDuration\":").append(this.maxForbiddenCheckDuration)
-                .append(",\"sessionStatisticCheckDuration\":").append(this.sessionStatisticCheckDuration)
-                .append(",\"sessionWarnForbiddenRate\":").append(this.sessionWarnForbiddenRate)
-                .append(",\"sessionWarnDelayedMsgCount\":").append(this.sessionWarnDelayedMsgCount)
-                .append(",\"linkMaxAllowedDelayedMsgCount\":").append(this.linkMaxAllowedDelayedMsgCount)
-                .append(",\"sessionMaxAllowedDelayedMsgCount\":").append(this.sessionMaxAllowedDelayedMsgCount)
-                .append(",\"enableUserAuthentic\":").append(this.enableUserAuthentic)
-                .append(",\"usrName\":\"").append(this.usrName)
-                .append("\",\"usrPassWord\":\"").append(this.usrPassWord)
-                .append("\",").append(this.tlsConfig.toString())
-                .append("}").toString();
+            .append(",\"rpcConnProcesserCnt\":").append(this.rpcConnProcesserCnt)
+            .append(",\"rpcNnettyWorkMemorySize\":").append(this.rpcNnettyWorkMemorySize)
+            .append(",\"rpcRspCallBackThreadCnt\":").append(this.rpcRspCallBackThreadCnt)
+            .append(",\"nettyWriteBufferHighWaterMark\":").append(this.nettyWriteBufferHighWaterMark)
+            .append(",\"nettyWriteBufferLowWaterMark\":").append(this.nettyWriteBufferLowWaterMark)
+            .append(",\"maxRegisterRetryTimes\":").append(this.maxRegisterRetryTimes)
+            .append(",\"regFailWaitPeriodMs\":").append(this.regFailWaitPeriodMs)
+            .append(",\"maxHeartBeatRetryTimes\":").append(this.maxHeartBeatRetryTimes)
+            .append(",\"heartbeatPeriodMs\":").append(this.heartbeatPeriodMs)
+            .append(",\"heartbeatPeriodAfterFail\":").append(this.heartbeatPeriodAfterFail)
+            .append(",\"linkStatsDurationMs\":").append(this.linkStatsDurationMs)
+            .append(",\"linkStatsForbiddenDurationMs\":").append(this.linkStatsForbiddenDurationMs)
+            .append(",\"linkStatsMaxAllowedFailTimes\":").append(this.linkStatsMaxAllowedFailTimes)
+            .append(",\"linkStatsMaxForbiddenRate\":").append(this.linkStatsMaxForbiddenRate)
+            .append(",\"maxSentForbiddenRate\":").append(this.maxSentForbiddenRate)
+            .append(",\"maxForbiddenCheckDuration\":").append(this.maxForbiddenCheckDuration)
+            .append(",\"sessionStatisticCheckDuration\":").append(this.sessionStatisticCheckDuration)
+            .append(",\"sessionWarnForbiddenRate\":").append(this.sessionWarnForbiddenRate)
+            .append(",\"sessionWarnDelayedMsgCount\":").append(this.sessionWarnDelayedMsgCount)
+            .append(",\"linkMaxAllowedDelayedMsgCount\":").append(this.linkMaxAllowedDelayedMsgCount)
+            .append(",\"sessionMaxAllowedDelayedMsgCount\":").append(this.sessionMaxAllowedDelayedMsgCount)
+            .append(",\"unAvailableFbdDurationMs\":").append(this.unAvailableFbdDurationMs)
+            .append(",\"enableUserAuthentic\":").append(this.enableUserAuthentic)
+            .append(",\"usrName\":\"").append(this.usrName)
+            .append("\",\"usrPassWord\":\"").append(this.usrPassWord)
+            .append("\",").append(this.tlsConfig.toString())
+            .append("}").toString();
     }
 }

--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/factory/TubeBaseSessionFactory.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/factory/TubeBaseSessionFactory.java
@@ -66,6 +66,8 @@ public class TubeBaseSessionFactory implements InnerSessionFactory {
                 tubeClientConfig.getLinkStatsMaxAllowedFailTimes());
         config.put(RpcConstants.RPC_LQ_MAX_FAIL_FORBIDDEN_RATE,
                 tubeClientConfig.getLinkStatsMaxForbiddenRate());
+        config.put(RpcConstants.RPC_SERVICE_UNAVAILABLE_FORBIDDEN_DURATION,
+            tubeClientConfig.getUnAvailableFbdDurationMs());
         this.rpcServiceFactory = new RpcServiceFactory(clientFactory, config);
         this.producerManager = new ProducerManager(this, this.tubeClientConfig);
         this.brokerRcvQltyStats =

--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/producer/SimpleMessageProducer.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/producer/SimpleMessageProducer.java
@@ -71,7 +71,7 @@ public class SimpleMessageProducer implements MessageProducer {
         java.security.Security.setProperty("networkaddress.cache.negative.ttl", "1");
         if (sessionFactory == null || tubeClientConfig == null) {
             throw new TubeClientException(
-                    "Illegal parameter: messageSessionFactory or tubeClientConfig is null!");
+                "Illegal parameter: messageSessionFactory or tubeClientConfig is null!");
         }
         this.producerConfig = tubeClientConfig;
         this.sessionFactory = sessionFactory;
@@ -81,19 +81,19 @@ public class SimpleMessageProducer implements MessageProducer {
         this.partitionRouter = new RoundRobinPartitionRouter();
         this.rpcConfig.put(RpcConstants.CONNECT_TIMEOUT, 3000);
         this.rpcConfig.put(RpcConstants.REQUEST_TIMEOUT,
-                tubeClientConfig.getRpcTimeoutMs());
+            tubeClientConfig.getRpcTimeoutMs());
         this.rpcConfig.put(RpcConstants.NETTY_WRITE_HIGH_MARK,
-                tubeClientConfig.getNettyWriteBufferHighWaterMark());
+            tubeClientConfig.getNettyWriteBufferHighWaterMark());
         this.rpcConfig.put(RpcConstants.NETTY_WRITE_LOW_MARK,
-                tubeClientConfig.getNettyWriteBufferLowWaterMark());
+            tubeClientConfig.getNettyWriteBufferLowWaterMark());
         this.rpcConfig.put(RpcConstants.WORKER_COUNT,
-                tubeClientConfig.getRpcConnProcesserCnt());
+            tubeClientConfig.getRpcConnProcesserCnt());
         this.rpcConfig.put(RpcConstants.WORKER_THREAD_NAME,
-                "tube_producer_netty_worker-");
+            "tube_producer_netty_worker-");
         this.rpcConfig.put(RpcConstants.WORKER_MEM_SIZE,
-                tubeClientConfig.getRpcNettyWorkMemorySize());
+            tubeClientConfig.getRpcNettyWorkMemorySize());
         this.rpcConfig.put(RpcConstants.CALLBACK_WORKER_COUNT,
-                tubeClientConfig.getRpcRspCallBackThreadCnt());
+            tubeClientConfig.getRpcRspCallBackThreadCnt());
     }
 
     /**
@@ -211,6 +211,10 @@ public class SimpleMessageProducer implements MessageProducer {
                             AddressUtils.getLocalAddress(), producerConfig.isTlsEnable());
             rpcServiceFactory.resetRmtAddrErrCount(partition.getBroker().getBrokerAddr());
             this.brokerRcvQltyStats.addReceiveStatistic(brokerId, response.getSuccess());
+            if (!response.getSuccess()
+                && response.getErrCode() == TErrCodeConstants.SERVICE_UNAVILABLE) {
+                rpcServiceFactory.addUnavailableBroker(brokerId);
+            }
             return this.buildMsgSentResult(message, partition, response);
         } catch (final Throwable e) {
             if (e instanceof LocalConnException) {
@@ -247,6 +251,10 @@ public class SimpleMessageProducer implements MessageProducer {
                             partition.resetRetries();
                             brokerRcvQltyStats.addReceiveStatistic(brokerId,
                                     responseB2P.getSuccess());
+                            if (!responseB2P.getSuccess()
+                                && responseB2P.getErrCode() == TErrCodeConstants.SERVICE_UNAVILABLE) {
+                                rpcServiceFactory.addUnavailableBroker(brokerId);
+                            }
                             cb.onMessageSent(rt);
                         }
 

--- a/tubemq-client/src/test/java/com/tencent/tubemq/client/producer/qltystats/DefaultBrokerRcvQltyStatsTest.java
+++ b/tubemq-client/src/test/java/com/tencent/tubemq/client/producer/qltystats/DefaultBrokerRcvQltyStatsTest.java
@@ -39,6 +39,7 @@ public class DefaultBrokerRcvQltyStatsTest {
     public void testStartBrokerStatistic() throws Exception {
         RpcServiceFactory rpcServiceFactory = mock(RpcServiceFactory.class);
         when(rpcServiceFactory.getForbiddenAddrMap()).thenReturn(new ConcurrentHashMap<String, Long>());
+        when(rpcServiceFactory.getUnavilableBrokerMap()).thenReturn(new ConcurrentHashMap<Integer, Long>());
 
         TubeClientConfig config = mock(TubeClientConfig.class);
         when(config.getSessionMaxAllowedDelayedMsgCount()).thenReturn(1000L);

--- a/tubemq-core/src/main/java/com/tencent/tubemq/corebase/utils/ServiceStatusHolder.java
+++ b/tubemq-core/src/main/java/com/tencent/tubemq/corebase/utils/ServiceStatusHolder.java
@@ -61,8 +61,8 @@ public class ServiceStatusHolder {
             isServiceStopped.set(isStopped);
             if (isStopped) {
                 logger.warn(new StringBuilder(256)
-                        .append("[Service Status]: global-write stopped by caller ")
-                        .append(caller).toString());
+                    .append("[Service Status]: global-write stopped by caller ")
+                    .append(caller).toString());
             }
         }
     }
@@ -124,8 +124,8 @@ public class ServiceStatusHolder {
             isReadStopped.set(isReadStop);
             if (isReadStop) {
                 logger.warn(new StringBuilder(256)
-                        .append("[Service Status]: global-read stopped by caller ")
-                        .append(caller).toString());
+                    .append("[Service Status]: global-read stopped by caller ")
+                    .append(caller).toString());
             } else {
                 if (isPauseRead.get()) {
                     isPauseRead.set(false);
@@ -133,16 +133,16 @@ public class ServiceStatusHolder {
                     lastReadStatsTime.set(System.currentTimeMillis());
                 }
                 logger.warn(new StringBuilder(256)
-                        .append("[Service Status]: global-read opened by caller ")
-                        .append(caller).toString());
+                    .append("[Service Status]: global-read opened by caller ")
+                    .append(caller).toString());
             }
         }
         if (isWriteStopped.get() != isWriteStop) {
             isWriteStopped.set(isWriteStop);
             if (isWriteStop) {
                 logger.warn(new StringBuilder(256)
-                        .append("[Service Status]: global-write stopped by caller ")
-                        .append(caller).toString());
+                    .append("[Service Status]: global-write stopped by caller ")
+                    .append(caller).toString());
             } else {
                 if (isPauseWrite.get()) {
                     isPauseWrite.set(false);
@@ -150,8 +150,8 @@ public class ServiceStatusHolder {
                     lastWriteStatsTime.set(System.currentTimeMillis());
                 }
                 logger.warn(new StringBuilder(256)
-                        .append("[Service Status]: global-write opened by caller ")
-                        .append(caller).toString());
+                    .append("[Service Status]: global-write opened by caller ")
+                    .append(caller).toString());
             }
         }
     }

--- a/tubemq-core/src/main/java/com/tencent/tubemq/corerpc/RpcConstants.java
+++ b/tubemq-core/src/main/java/com/tencent/tubemq/corerpc/RpcConstants.java
@@ -61,7 +61,8 @@ public final class RpcConstants {
     public static final String RPC_LQ_FORBIDDEN_DURATION = "rpc.link.quality.forbidden.duration";
     public static final String RPC_LQ_MAX_ALLOWED_FAIL_COUNT = "rpc.link.quality.max.allowed.fail.count";
     public static final String RPC_LQ_MAX_FAIL_FORBIDDEN_RATE = "rpc.link.quality.max.fail.forbidden.rate";
-
+    public static final String RPC_SERVICE_UNAVAILABLE_FORBIDDEN_DURATION =
+        "rpc.unavailable.service.forbidden.duration";
     public static final int RPC_PROTOCOL_BEGIN_TOKEN = 0xFF7FF4FE;
     public static final int RPC_MAX_BUFFER_SIZE = 8192;
     public static final int MAX_FRAME_MAX_LIST_SIZE =
@@ -122,7 +123,7 @@ public final class RpcConstants {
     public static final long CFG_LQ_FORBIDDEN_DURATION_MS = 1800000;
     public static final int CFG_LQ_MAX_ALLOWED_FAIL_COUNT = 5;
     public static final double CFG_LQ_MAX_FAIL_FORBIDDEN_RATE = 0.3;
-
+    public static final long CFG_UNAVAILABLE_FORBIDDEN_DURATION_MS = 50000;
     public static final long CFG_DEFAULT_NETTY_WRITEBUFFER_HIGH_MARK = 50 * 1024 * 1024;
     public static final long CFG_DEFAULT_NETTY_WRITEBUFFER_LOW_MARK = 5 * 1024 * 1024;
 


### PR DESCRIPTION
Optimize the client's handling logic for SERVICE_UNAVILABLE error: If the production side receives the response message, it will block the Broker for a period of time, and if the consumption receives the response message, it will also be blocked (the consumption side has little effect, and it is the same as the previous value for the time being).
- - - - - - - - - 
优化客户端对SERVICE_UNAVILABLE错误的处理逻辑：如果生产端收到该响应消息，则屏蔽该Broker一段时间，如果消费收到该响应消息也屏蔽（消费端影响不大，暂时与之前值相同）