### PR TITLE
Optimization, the values of consumer group are allowed to contain hyphen character

### DIFF
--- a/tubemq-client/src/main/java/com/tencent/tubemq/client/config/ConsumerConfig.java
+++ b/tubemq-client/src/main/java/com/tencent/tubemq/client/config/ConsumerConfig.java
@@ -191,11 +191,11 @@ public class ConsumerConfig extends TubeClientConfig {
                     .append(TBaseConstants.META_MAX_GROUPNAME_LENGTH)
                     .append(" characters").toString());
         }
-        if (!tmpConsumerGroup.matches(TBaseConstants.META_TMP_STRING_VALUE)) {
+        if (!tmpConsumerGroup.matches(TBaseConstants.META_TMP_GROUP_VALUE)) {
             throw new Exception(new StringBuilder(512)
                     .append("Illegal parameter: the value of consumerGroup")
                     .append(" must begin with a letter, ")
-                    .append("can only contain characters,numbers,and underscores").toString());
+                    .append("can only contain characters,numbers,hyphen,and underscores").toString());
         }
     }
 

--- a/tubemq-core/src/main/java/com/tencent/tubemq/corebase/TBaseConstants.java
+++ b/tubemq-core/src/main/java/com/tencent/tubemq/corebase/TBaseConstants.java
@@ -43,6 +43,7 @@ public class TBaseConstants {
     public static final String META_TMP_FILTER_VALUE = "^[_A-Za-z0-9]+$";
     public static final String META_TMP_STRING_VALUE = "^[a-zA-Z]\\w+$";
     public static final String META_TMP_NUMBER_VALUE = "^-?[0-9]\\d*$";
+    public static final String META_TMP_GROUP_VALUE = "^[a-zA-Z][\\w-]+$";
     public static final String META_TMP_CONSUMERID_VALUE = "^[_A-Za-z0-9\\.\\-]+$";
     public static final String META_TMP_CALLBACK_STRING_VALUE = "^[_A-Za-z0-9]+$";
     public static final String META_TMP_DATE_VALUE = "yyyyMMddHHmmss";


### PR DESCRIPTION
Some businesses include the hyphen character in the consumer group, expand the allowed range of the character set of the effective consumer group name, and increase the hyphen character
- - - - - 
有业务在消费组组名里包含了中划线，扩大对有效消费组组名字符集的允许范围，增加中划线字符